### PR TITLE
Update to Gatling 3.3.0, Scala 2.12 and Fusesource MQTT 1.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ name := "gatling-mqtt"
 
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
-  "io.gatling" % "gatling-core" % "2.2.3" % "provided",
-  "org.fusesource.mqtt-client" % "mqtt-client" % "1.14"
+  "io.gatling" % "gatling-core" % "3.3.0" % "provided",
+  "org.fusesource.mqtt-client" % "mqtt-client" % "1.16"
 )
 
 // Gatling contains scala-library

--- a/src/main/scala/com/github/mnogu/gatling/mqtt/action/MqttRequestConnectAction.scala
+++ b/src/main/scala/com/github/mnogu/gatling/mqtt/action/MqttRequestConnectAction.scala
@@ -2,7 +2,7 @@ package com.github.mnogu.gatling.mqtt.action
 
 import com.github.mnogu.gatling.mqtt.protocol.MqttProtocol
 import io.gatling.commons.stats.OK
-import io.gatling.commons.util.ClockSingleton._
+import io.gatling.commons.util.Clock
 import io.gatling.commons.validation.Validation
 import io.gatling.core.CoreComponents
 import io.gatling.core.Predef._
@@ -16,6 +16,7 @@ class MqttRequestConnectAction(
   val requestName : Expression[String],
   val coreComponents : CoreComponents,
   val mqttProtocol: MqttProtocol,
+  val clock: Clock,
   val next: Action)
    extends ExitableAction with NameGen {
 
@@ -175,7 +176,7 @@ class MqttRequestConnectAction(
 
       val connection = resolvedMqtt.callbackConnection()
 
-      val requestStartDate = nowMillis
+      val requestStartDate = clock.nowMillis
 
       connection.connect(new Callback[Void] {
         override def onSuccess(void: Void): Unit = {

--- a/src/main/scala/com/github/mnogu/gatling/mqtt/action/MqttRequestConnectActionBuilder.scala
+++ b/src/main/scala/com/github/mnogu/gatling/mqtt/action/MqttRequestConnectActionBuilder.scala
@@ -20,6 +20,7 @@ class MqttRequestConnectActionBuilder(requestName: Expression[String])
       requestName,
       coreComponents,
       mqttComponents.mqttProtocol,
+      coreComponents.clock,
       next
     )
   }

--- a/src/main/scala/com/github/mnogu/gatling/mqtt/action/MqttRequestPublishActionBuilder.scala
+++ b/src/main/scala/com/github/mnogu/gatling/mqtt/action/MqttRequestPublishActionBuilder.scala
@@ -20,6 +20,7 @@ class MqttRequestPublishActionBuilder(mqttAttributes: MqttAttributes)
       mqttAttributes,
       coreComponents,
       mqttComponents.mqttProtocol,
+      coreComponents.clock,
       next
     )
   }

--- a/src/main/scala/com/github/mnogu/gatling/mqtt/protocol/MqttComponents.scala
+++ b/src/main/scala/com/github/mnogu/gatling/mqtt/protocol/MqttComponents.scala
@@ -7,7 +7,7 @@ import io.gatling.core.session.Session
   *
   */
 case class MqttComponents(mqttProtocol: MqttProtocol) extends ProtocolComponents {
-    override def onStart: Option[(Session) => Session] = None
+    override def onStart: Session => Session = ProtocolComponents.NoopOnStart
 
-    override def onExit: Option[(Session) => Unit] = None
+    override def onExit: Session => Unit = ProtocolComponents.NoopOnExit
 }

--- a/src/main/scala/com/github/mnogu/gatling/mqtt/protocol/MqttProtocol.scala
+++ b/src/main/scala/com/github/mnogu/gatling/mqtt/protocol/MqttProtocol.scala
@@ -36,16 +36,13 @@ object MqttProtocol {
       maxReadRate = None,
       maxWriteRate = None))
 
-  val MqttProtocolKey = new ProtocolKey {
-
-    type Protocol = MqttProtocol
-    type Components = MqttComponents
+  val MqttProtocolKey = new ProtocolKey[MqttProtocol, MqttComponents]{
 
     def protocolClass: Class[io.gatling.core.protocol.Protocol] = classOf[MqttProtocol].asInstanceOf[Class[io.gatling.core.protocol.Protocol]]
 
     def defaultProtocolValue(configuration: GatlingConfiguration): MqttProtocol = MqttProtocol(configuration)
 
-    def newComponents(system: ActorSystem, coreComponents: CoreComponents): MqttProtocol => MqttComponents = {
+    def newComponents(coreComponents: CoreComponents): MqttProtocol => MqttComponents = {
 
       mqttProdocol => {
         val mqttComponents = MqttComponents (

--- a/src/test/scala/com/github/mnogu/gatling/mqtt/test/MqttSimulation.scala
+++ b/src/test/scala/com/github/mnogu/gatling/mqtt/test/MqttSimulation.scala
@@ -26,6 +26,6 @@ class MqttSimulation extends Simulation {
 
   setUp(
     scn
-      .inject(rampUsers(10) over (1 seconds))
+      .inject(rampUsers(10) during (1 seconds))
   ).protocols(mqttConf)
 }


### PR DESCRIPTION
As stated in the title: updated the MQTT plugin to work with Gatling 3.3.0, which uses Scala 2.12.

Also updated the MQTT client to the latest version.